### PR TITLE
Fix ruby gem deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,10 @@ source ENV["GEM_SOURCE"] || "https://rubygems.org"
 
 group :test do
   gem "rspec", "3.7.0"
-  gem "inspec", "1.49.2"
-  gem "test-kitchen", "1.19.2"
+  gem "inspec", "1.51.15"
+  gem "test-kitchen", "1.20.0"
   gem "kitchen-google", "1.4.0"
-  gem "kitchen-inspec", "0.20.0"
+  gem "kitchen-inspec", "0.22.0"
   gem "rubocop", "0.52.1"
+  gem "ffi", "1.9.18"
 end


### PR DESCRIPTION
The latest version of the ffi gem does
not compile. Pin ffi to an older version.